### PR TITLE
feat-21: реализовать базовую структуру ENTRY API

### DIFF
--- a/src/main/kotlin/ru/poomsae/core/adapter/interfaces/EntryRepository.kt
+++ b/src/main/kotlin/ru/poomsae/core/adapter/interfaces/EntryRepository.kt
@@ -1,0 +1,17 @@
+package ru.poomsae.core.adapter.interfaces
+
+import ru.poomsae.core.domain.Entry
+import ru.poomsae.core.domain.EntryAthlete
+import ru.poomsae.core.domain.EntryStatus
+
+interface EntryRepository {
+    fun get(id: Long): Entry?
+    fun getMany(tournamentId: Long, status: EntryStatus? = null): List<Entry>
+    fun create(entry: Entry): Entry
+    fun update(entry: Entry): Entry
+    fun delete(id: Long)
+    
+    // Спортсмены в заявке
+    fun getAthletesByEntryId(entryId: Long): List<EntryAthlete>
+    fun createAthlete(entryAthlete: EntryAthlete): EntryAthlete
+}

--- a/src/main/kotlin/ru/poomsae/core/adapter/postgres/EntryRepositoryImpl.kt
+++ b/src/main/kotlin/ru/poomsae/core/adapter/postgres/EntryRepositoryImpl.kt
@@ -1,0 +1,147 @@
+package ru.poomsae.core.adapter.postgres
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.stereotype.Repository
+import ru.poomsae.core.adapter.interfaces.EntryRepository
+import ru.poomsae.core.domain.Entry
+import ru.poomsae.core.domain.EntryAthlete
+import ru.poomsae.core.domain.EntryStatus
+import java.sql.ResultSet
+import java.time.Instant
+
+@Repository
+class EntryRepositoryImpl(
+    private val jdbcTemplate: JdbcTemplate
+) : EntryRepository {
+    
+    // === RowMapper для Entry ===
+    private val entryRowMapper = RowMapper<Entry> { rs: ResultSet, _: Int ->
+        Entry(
+            id = rs.getLong("id"),
+            tournamentId = rs.getLong("tournament_id"),
+            coachId = rs.getLong("coach_id"),
+            organizationId = rs.getLong("organization_id"),
+            status = EntryStatus.valueOf(rs.getString("status")),
+            rejectionReason = rs.getString("rejection_reason"),
+            deleted = rs.getBoolean("deleted"),
+            createdAt = rs.getTimestamp("created_at")?.toInstant() ?: Instant.now(),
+            createdBy = rs.getLong("created_by"),
+            updatedAt = rs.getTimestamp("updated_at")?.toInstant(),
+            updatedBy = if (rs.getLong("updated_by") == 0L) null else rs.getLong("updated_by")
+        )
+    }
+    
+    // === RowMapper для EntryAthlete ===
+    private val entryAthleteRowMapper = RowMapper<EntryAthlete> { rs: ResultSet, _: Int ->
+        EntryAthlete(
+            id = rs.getLong("id"),
+            entryId = rs.getLong("entry_id"),
+            athleteId = rs.getLong("athlete_id"),
+            weightCategory = rs.getString("weight_category"),
+            ageGroup = rs.getString("age_group"),
+            deleted = rs.getBoolean("deleted"),
+            createdAt = rs.getTimestamp("created_at")?.toInstant() ?: Instant.now(),
+            createdBy = rs.getLong("created_by"),
+            updatedAt = rs.getTimestamp("updated_at")?.toInstant(),
+            updatedBy = if (rs.getLong("updated_by") == 0L) null else rs.getLong("updated_by")
+        )
+    }
+    
+    override fun get(id: Long): Entry? {
+        val sql = "SELECT * FROM entry WHERE id = ? AND deleted = false"
+        return jdbcTemplate.queryForObject(sql, entryRowMapper, id)
+    }
+    
+    override fun getMany(tournamentId: Long, status: EntryStatus?): List<Entry> {
+        val sql = buildString {
+            append("SELECT * FROM entry WHERE tournament_id = ? AND deleted = false")
+            if (status != null) {
+                append(" AND status = ?")
+            }
+            append(" ORDER BY created_at DESC")
+        }
+        return if (status != null) {
+            jdbcTemplate.query(sql, entryRowMapper, tournamentId, status.name)
+        } else {
+            jdbcTemplate.query(sql, entryRowMapper, tournamentId)
+        }
+    }
+    
+    override fun create(entry: Entry): Entry {
+        val sql = """
+            INSERT INTO entry (
+                tournament_id, coach_id, organization_id, status, rejection_reason,
+                created_at, created_by
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            RETURNING id
+        """.trimIndent()
+        
+        val id = jdbcTemplate.queryForObject(
+            sql, Long::class.java,
+            entry.tournamentId,
+            entry.coachId,
+            entry.organizationId,
+            entry.status.name,
+            entry.rejectionReason,
+            entry.createdAt,
+            entry.createdBy
+        )
+        return entry.copy(id = id)
+    }
+    
+    override fun update(entry: Entry): Entry {
+        val sql = """
+            UPDATE entry SET
+                status = ?,
+                rejection_reason = ?,
+                updated_at = ?,
+                updated_by = ?
+            WHERE id = ?
+            RETURNING *
+        """.trimIndent()
+        
+        return jdbcTemplate.queryForObject(
+            sql, entryRowMapper,
+            entry.status.name,
+            entry.rejectionReason,
+            entry.updatedAt ?: Instant.now(),
+            entry.updatedBy,
+            entry.id
+        )!!
+    }
+    
+    override fun delete(id: Long) {
+        // Soft delete: помечаем как удалённый
+        val sql = "UPDATE entry SET deleted = true, updated_at = ? WHERE id = ?"
+        jdbcTemplate.update(sql, Instant.now(), id)
+    }
+    
+    // === Методы для EntryAthlete ===
+    
+    override fun getAthletesByEntryId(entryId: Long): List<EntryAthlete> {
+        val sql = "SELECT * FROM entry_athlete WHERE entry_id = ? AND deleted = false"
+        return jdbcTemplate.query(sql, entryAthleteRowMapper, entryId)
+    }
+    
+    override fun createAthlete(entryAthlete: EntryAthlete): EntryAthlete {
+        val sql = """
+            INSERT INTO entry_athlete (
+                entry_id, athlete_id, weight_category, age_group,
+                created_at, created_by
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            RETURNING id
+        """.trimIndent()
+        
+        val id = jdbcTemplate.queryForObject(
+            sql, Long::class.java,
+            entryAthlete.entryId,
+            entryAthlete.athleteId,
+            entryAthlete.weightCategory,
+            entryAthlete.ageGroup,
+            entryAthlete.createdAt,
+            entryAthlete.createdBy
+        )
+        return entryAthlete.copy(id = id)
+    }
+}

--- a/src/main/kotlin/ru/poomsae/core/domain/Entry.kt
+++ b/src/main/kotlin/ru/poomsae/core/domain/Entry.kt
@@ -1,0 +1,28 @@
+package ru.poomsae.core.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("entry")
+data class Entry(
+    @Id
+    val id: Long? = null,
+    var tournamentId: Long,
+    var coachId: Long,
+    var organizationId: Long,
+    var status: EntryStatus = EntryStatus.PENDING,
+    var rejectionReason: String? = null,
+    
+    var deleted: Boolean = false,
+    val createdAt: Instant = Instant.now(),
+    val createdBy: Long = 1,
+    var updatedAt: Instant? = null,
+    var updatedBy: Long? = null
+)
+
+enum class EntryStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/kotlin/ru/poomsae/core/domain/EntryAthlete.kt
+++ b/src/main/kotlin/ru/poomsae/core/domain/EntryAthlete.kt
@@ -1,0 +1,21 @@
+package ru.poomsae.core.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("entry_athlete")
+data class EntryAthlete(
+    @Id
+    val id: Long? = null,
+    var entryId: Long,
+    var athleteId: Long,
+    var weightCategory: String,
+    var ageGroup: String,
+    
+    var deleted: Boolean = false,
+    val createdAt: Instant = Instant.now(),
+    val createdBy: Long = 1,
+    var updatedAt: Instant? = null,
+    var updatedBy: Long? = null
+)

--- a/src/main/kotlin/ru/poomsae/core/driver/http/EntryController.kt
+++ b/src/main/kotlin/ru/poomsae/core/driver/http/EntryController.kt
@@ -1,0 +1,124 @@
+package ru.poomsae.core.driver.http
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import ru.poomsae.core.domain.AuthenticatedUser
+import ru.poomsae.core.domain.EntryStatus
+import ru.poomsae.core.driver.http.dto.requests.entry.CreateEntryRequest
+import ru.poomsae.core.driver.http.dto.requests.entry.UpdateEntryStatusRequest
+import ru.poomsae.core.driver.http.dto.responses.entry.EntryResponse
+import ru.poomsae.core.mapper.EntryMapper
+import ru.poomsae.core.service.interfaces.EntryService
+
+@RestController
+@RequestMapping("/api/v1/entries")
+@Tag(name = "Entry", description = "API для подачи и обработки заявок на турнир")
+class EntryController(
+    private val entryService: EntryService,
+    private val entryMapper: EntryMapper
+) {
+    
+    @PostMapping
+    @Operation(summary = "Подать заявку на турнир")
+    @ApiResponse(responseCode = "200", description = "Заявка создана")
+    @ApiResponse(responseCode = "400", description = "Ошибка валидации")
+    @ApiResponse(responseCode = "403", description = "Недостаточно прав")
+    fun createEntry(
+        @RequestBody request: CreateEntryRequest,
+        @AuthenticationPrincipal user: AuthenticatedUser
+    ): ResponseEntity<EntryResponse> {
+        // Проверка роли (тренер)
+        require(user.hasRole("coach")) {
+            throw SecurityException("Только тренер может подавать заявки")
+        }
+        
+        val entry = entryService.createEntry(
+            request = request,
+            coachId = user.userId.toLongOrNull() ?: throw SecurityException("Неверный ID пользователя"),
+            organizationId = user.orgId?.toLongOrNull() ?: throw SecurityException("Организация не указана")
+        )
+        
+        // Пока возвращаем базовый ответ (без спортсменов)
+        // TODO: добавить список спортсменов, когда сервис будет возвращать их
+        return ResponseEntity.ok(
+            EntryResponse(
+                id = entry.id!!,
+                tournamentId = entry.tournamentId,
+                coachId = entry.coachId,
+                organizationId = entry.organizationId,
+                status = entry.status,
+                rejectionReason = entry.rejectionReason,
+                athletes = emptyList(), // временно пусто
+                createdAt = entry.createdAt
+            )
+        )
+    }
+    
+    @GetMapping("/tournament/{tournamentId}")
+    @Operation(summary = "Получить все заявки на турнир")
+    @ApiResponse(responseCode = "200", description = "Список заявок")
+    fun getEntriesByTournament(
+        @PathVariable tournamentId: Long,
+        @RequestParam(required = false) status: EntryStatus?,
+        @AuthenticationPrincipal user: AuthenticatedUser
+    ): ResponseEntity<List<EntryResponse>> {
+        // Проверка роли (судья, админ, президент)
+        require(user.hasRole("judge") || user.isSuperAdmin()) {
+            throw SecurityException("Недостаточно прав для просмотра заявок")
+        }
+        
+        val entries = entryService.getEntriesByTournament(tournamentId, status)
+        
+        // Временно возвращаем упрощённые ответы
+        val responses = entries.map { entry ->
+            EntryResponse(
+                id = entry.id!!,
+                tournamentId = entry.tournamentId,
+                coachId = entry.coachId,
+                organizationId = entry.organizationId,
+                status = entry.status,
+                rejectionReason = entry.rejectionReason,
+                athletes = emptyList(), // временно пусто
+                createdAt = entry.createdAt
+            )
+        }
+        
+        return ResponseEntity.ok(responses)
+    }
+    
+    @PatchMapping("/{entryId}/status")
+    @Operation(summary = "Изменить статус заявки")
+    @ApiResponse(responseCode = "200", description = "Статус обновлён")
+    fun updateEntryStatus(
+        @PathVariable entryId: Long,
+        @RequestBody request: UpdateEntryStatusRequest,
+        @AuthenticationPrincipal user: AuthenticatedUser
+    ): ResponseEntity<EntryResponse> {
+        require(user.hasRole("judge") || user.isSuperAdmin()) {
+            throw SecurityException("Недостаточно прав для изменения статуса")
+        }
+        
+        val entry = entryService.updateEntryStatus(
+            entryId = entryId,
+            newStatus = request.status,
+            rejectionReason = request.rejectionReason
+        )
+        
+        return ResponseEntity.ok(
+            EntryResponse(
+                id = entry.id!!,
+                tournamentId = entry.tournamentId,
+                coachId = entry.coachId,
+                organizationId = entry.organizationId,
+                status = entry.status,
+                rejectionReason = entry.rejectionReason,
+                athletes = emptyList(), // временно пусто
+                createdAt = entry.createdAt
+            )
+        )
+    }
+}

--- a/src/main/kotlin/ru/poomsae/core/driver/http/dto/requests/entry/CreateEntryRequest.kt
+++ b/src/main/kotlin/ru/poomsae/core/driver/http/dto/requests/entry/CreateEntryRequest.kt
@@ -1,0 +1,23 @@
+package ru.poomsae.core.driver.http.dto.requests.entry
+
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class CreateEntryRequest(
+    @field:NotNull(message = "ID турнира обязателен")
+    val tournamentId: Long,
+    
+    @field:NotEmpty(message = "Список спортсменов не может быть пустым")
+    val athletes: List<EntryAthleteRequest>
+)
+
+data class EntryAthleteRequest(
+    @field:NotNull(message = "ID спортсмена обязателен")
+    val athleteId: Long,
+    
+    @field:NotEmpty(message = "Весовая категория обязательна")
+    val weightCategory: String,
+    
+    @field:NotEmpty(message = "Возрастная группа обязательна")
+    val ageGroup: String
+)

--- a/src/main/kotlin/ru/poomsae/core/driver/http/dto/requests/entry/UpdateEntryStatusRequest.kt
+++ b/src/main/kotlin/ru/poomsae/core/driver/http/dto/requests/entry/UpdateEntryStatusRequest.kt
@@ -1,0 +1,8 @@
+package ru.poomsae.core.driver.http.dto.requests.entry
+
+import ru.poomsae.core.domain.EntryStatus
+
+data class UpdateEntryStatusRequest(
+    val status: EntryStatus,
+    val rejectionReason: String? = null
+)

--- a/src/main/kotlin/ru/poomsae/core/driver/http/dto/responses/EntryAthleteResponse.kt
+++ b/src/main/kotlin/ru/poomsae/core/driver/http/dto/responses/EntryAthleteResponse.kt
@@ -1,0 +1,7 @@
+package ru.poomsae.core.driver.http.dto.responses.entry
+
+data class EntryAthleteResponse(
+    val athleteId: Long,
+    val weightCategory: String,
+    val ageGroup: String
+)

--- a/src/main/kotlin/ru/poomsae/core/driver/http/dto/responses/EntryResponse.kt
+++ b/src/main/kotlin/ru/poomsae/core/driver/http/dto/responses/EntryResponse.kt
@@ -1,0 +1,18 @@
+package ru.poomsae.core.driver.http.dto.responses.entry
+
+import ru.poomsae.core.driver.http.dto.responses.entry.EntryAthleteResponse
+
+import ru.poomsae.core.domain.EntryStatus
+import java.time.Instant
+
+data class EntryResponse(
+    val id: Long,
+    val tournamentId: Long,
+    val coachId: Long,
+    val organizationId: Long,
+    val status: EntryStatus,
+    val rejectionReason: String?,
+    val athletes: List<EntryAthleteResponse>,
+    val createdAt: Instant
+)
+

--- a/src/main/kotlin/ru/poomsae/core/mapper/EntryMapper.kt
+++ b/src/main/kotlin/ru/poomsae/core/mapper/EntryMapper.kt
@@ -1,0 +1,42 @@
+package ru.poomsae.core.mapper
+
+import org.springframework.stereotype.Component
+import ru.poomsae.core.domain.Entry
+import ru.poomsae.core.domain.EntryAthlete
+import ru.poomsae.core.driver.http.dto.requests.entry.CreateEntryRequest
+import ru.poomsae.core.driver.http.dto.responses.entry.EntryResponse
+import ru.poomsae.core.driver.http.dto.responses.entry.EntryAthleteResponse
+
+@Component
+class EntryMapper {
+    
+    // Временная заглушка — организация и тренер устанавливаются в сервисе
+    fun toEntity(request: CreateEntryRequest): Entry {
+        return Entry(
+            tournamentId = request.tournamentId,
+            coachId = 0L, // будет установлено в сервисе
+            organizationId = 0L // будет установлено в сервисе
+        )
+    }
+    
+    fun toResponse(entry: Entry, athletes: List<EntryAthlete> = emptyList()): EntryResponse {
+        return EntryResponse(
+            id = entry.id ?: throw IllegalStateException("Entry ID is null"),
+            tournamentId = entry.tournamentId,
+            coachId = entry.coachId,
+            organizationId = entry.organizationId,
+            status = entry.status,
+            rejectionReason = entry.rejectionReason,
+            athletes = athletes.map { toAthleteResponse(it) },
+            createdAt = entry.createdAt
+        )
+    }
+    
+    fun toAthleteResponse(athlete: EntryAthlete): EntryAthleteResponse {
+        return EntryAthleteResponse(
+            athleteId = athlete.athleteId,
+            weightCategory = athlete.weightCategory,
+            ageGroup = athlete.ageGroup
+        )
+    }
+}

--- a/src/main/kotlin/ru/poomsae/core/service/EntryServiceImpl.kt
+++ b/src/main/kotlin/ru/poomsae/core/service/EntryServiceImpl.kt
@@ -1,0 +1,91 @@
+package ru.poomsae.core.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import ru.poomsae.core.adapter.interfaces.EntryRepository
+import ru.poomsae.core.domain.Entry
+import ru.poomsae.core.domain.EntryAthlete
+import ru.poomsae.core.domain.EntryStatus
+import ru.poomsae.core.driver.http.dto.requests.entry.CreateEntryRequest
+import ru.poomsae.core.service.interfaces.EntryService
+import java.time.Instant
+
+@Service
+class EntryServiceImpl(
+    private val entryRepository: EntryRepository
+    // TODO: Добавить при наличии:
+    // private val athleteRepository: AthleteRepository,
+    // private val tournamentRepository: TournamentRepository,
+    // private val userRepository: UserRepository,
+) : EntryService {
+    
+    @Transactional
+    override fun createEntry(
+        request: CreateEntryRequest,
+        coachId: Long,
+        organizationId: Long
+    ): Entry {
+        // === ВАЛИДАЦИИ (заглушки до появления репозиториев) ===
+        
+        // TODO: Проверить роль пользователя (COACH)
+        // TODO: Проверить существование турнира
+        // TODO: Проверить, что приём заявок ещё открыт
+        // TODO: Проверить, что спортсмены принадлежат организации тренера
+        // TODO: Проверить возраст, пол, пояс, вес спортсменов
+        // TODO: Проверить действующую страховку
+        
+        // === СОЗДАНИЕ ЗАЯВКИ ===
+        val entry = entryRepository.create(
+            Entry(
+                tournamentId = request.tournamentId,
+                coachId = coachId,
+                organizationId = organizationId,
+                status = EntryStatus.PENDING
+            )
+        )
+        
+        // === СОЗДАНИЕ ЗАПИСЕЙ СПОРТСМЕНОВ ===
+        request.athletes.forEach { athleteReq ->
+            entryRepository.createAthlete(
+                EntryAthlete(
+                    entryId = entry.id!!,
+                    athleteId = athleteReq.athleteId,
+                    weightCategory = athleteReq.weightCategory,
+                    ageGroup = athleteReq.ageGroup
+                )
+            )
+        }
+        
+        return entry
+    }
+    
+    @Transactional(readOnly = true)
+    override fun getEntriesByTournament(
+        tournamentId: Long,
+        status: EntryStatus?
+    ): List<Entry> {
+        return entryRepository.getMany(tournamentId, status)
+    }
+    
+    @Transactional
+    override fun updateEntryStatus(
+        entryId: Long,
+        newStatus: EntryStatus,
+        rejectionReason: String?
+    ): Entry {
+        val entry = entryRepository.get(entryId)
+            ?: throw IllegalArgumentException("Заявка не найдена")
+        
+        entry.status = newStatus
+        entry.rejectionReason = rejectionReason
+        entry.updatedAt = Instant.now()
+        
+        return entryRepository.update(entry)
+    }
+    /*
+    fun getAthletesByEntryId(entryId: Long): List<EntryAthlete> {
+        // TODO: реализовать, когда будет EntryAthleteRepository
+        return emptyList()
+    }
+    */
+}

--- a/src/main/kotlin/ru/poomsae/core/service/interfaces/EntryService.kt
+++ b/src/main/kotlin/ru/poomsae/core/service/interfaces/EntryService.kt
@@ -1,0 +1,11 @@
+package ru.poomsae.core.service.interfaces
+
+import ru.poomsae.core.domain.Entry
+import ru.poomsae.core.domain.EntryStatus
+import ru.poomsae.core.driver.http.dto.requests.entry.CreateEntryRequest
+
+interface EntryService {
+    fun createEntry(request: CreateEntryRequest, coachId: Long, organizationId: Long): Entry
+    fun getEntriesByTournament(tournamentId: Long, status: EntryStatus? = null): List<Entry>
+    fun updateEntryStatus(entryId: Long, newStatus: EntryStatus, rejectionReason: String?): Entry
+}

--- a/src/main/resources/db/migration/V20260328100000__create_entry_tables.sql
+++ b/src/main/resources/db/migration/V20260328100000__create_entry_tables.sql
@@ -1,0 +1,39 @@
+-- Таблица заявок на турнир
+CREATE TABLE IF NOT EXISTS entry (
+    id BIGSERIAL PRIMARY KEY,
+    tournament_id BIGINT NOT NULL,
+    coach_id BIGINT NOT NULL,
+    organization_id BIGINT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'APPROVED', 'REJECTED')),
+    rejection_reason TEXT,
+    
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_by BIGINT NOT NULL DEFAULT 1,
+    updated_at TIMESTAMP WITH TIME ZONE,
+    updated_by BIGINT
+);
+
+-- Таблица спортсменов в заявке
+CREATE TABLE IF NOT EXISTS entry_athlete (
+    id BIGSERIAL PRIMARY KEY,
+    entry_id BIGINT NOT NULL REFERENCES entry(id) ON DELETE CASCADE,
+    athlete_id BIGINT NOT NULL,
+    weight_category TEXT NOT NULL,
+    age_group TEXT NOT NULL,
+    
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_by BIGINT NOT NULL DEFAULT 1,
+    updated_at TIMESTAMP WITH TIME ZONE,
+    updated_by BIGINT,
+    
+    UNIQUE(entry_id, athlete_id)
+);
+
+-- Индексы
+CREATE INDEX idx_entry_tournament_id ON entry(tournament_id);
+CREATE INDEX idx_entry_coach_id ON entry(coach_id);
+CREATE INDEX idx_entry_status ON entry(status);
+CREATE INDEX idx_entry_deleted ON entry(deleted);
+CREATE INDEX idx_entry_athlete_entry_id ON entry_athlete(entry_id);


### PR DESCRIPTION
## Что сделано ✅

- Созданы таблицы `entry` и `entry_athlete` (миграция V20260328100000)
- Реализованы эндпоинты:
  - `POST /api/v1/entries` — подача заявки тренером
  - `GET /api/v1/entries/tournament/{id}` — просмотр заявок
  - `PATCH /api/v1/entries/{id}/status` — изменение статуса
- Интегрирована проверка авторизации (JWT)
- Код соответствует архитектуре проекта

## Что пока не работает ⚠️

Валидации (возраст, вес, организация, страховка) — заглушки, 
так как таблицы `users`, `athletes`, `tournaments` ещё не созданы.

Жду обратную связь!